### PR TITLE
Add reflector interface

### DIFF
--- a/Buster.xcodeproj/project.pbxproj
+++ b/Buster.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		09A994DE1B71EAD50061A929 /* BTRSerialVocoderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09A994DD1B71EAD50061A929 /* BTRSerialVocoderView.xib */; };
 		09A994E01B7205C50061A929 /* BTRNetworkVocoderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 09A994DF1B7205C50061A929 /* BTRNetworkVocoderView.xib */; };
 		09AB117B1B5A13970067B9FB /* BTRSerialVocoderViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 09AB11791B5A13970067B9FB /* BTRSerialVocoderViewController.m */; };
+		09DBC7591BBAFB6200346912 /* BTRAddPopupController.m in Sources */ = {isa = PBXBuildFile; fileRef = 09DBC7581BBAFB6200346912 /* BTRAddPopupController.m */; settings = {ASSET_TAGS = (); }; };
 		09DFDA991B8C331300D00030 /* BTRMessageFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 09DFDA981B8C331300D00030 /* BTRMessageFormatter.m */; };
 		09DFDA9F1B8D6A9700D00030 /* BTRIRCDDBGateways.m in Sources */ = {isa = PBXBuildFile; fileRef = 09DFDA9E1B8D6A9700D00030 /* BTRIRCDDBGateways.m */; };
 		09E363EC1B66F46500F74DBB /* BTRSlowDataCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E363EB1B66F46500F74DBB /* BTRSlowDataCoder.m */; };
@@ -157,6 +158,8 @@
 		09AB11781B5A13970067B9FB /* BTRSerialVocoderViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTRSerialVocoderViewController.h; sourceTree = "<group>"; };
 		09AB11791B5A13970067B9FB /* BTRSerialVocoderViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTRSerialVocoderViewController.m; sourceTree = "<group>"; };
 		09AB117A1B5A13970067B9FB /* Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Prefix.pch; sourceTree = "<group>"; };
+		09DBC7571BBAFB6200346912 /* BTRAddPopupController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTRAddPopupController.h; sourceTree = "<group>"; };
+		09DBC7581BBAFB6200346912 /* BTRAddPopupController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTRAddPopupController.m; sourceTree = "<group>"; };
 		09DFDA971B8C331300D00030 /* BTRMessageFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTRMessageFormatter.h; sourceTree = "<group>"; };
 		09DFDA981B8C331300D00030 /* BTRMessageFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTRMessageFormatter.m; sourceTree = "<group>"; };
 		09DFDA9A1B8D191900D00030 /* BTRLinkDriverDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTRLinkDriverDelegate.h; sourceTree = "<group>"; };
@@ -258,6 +261,8 @@
 				09E363EB1B66F46500F74DBB /* BTRSlowDataCoder.m */,
 				09A5FDEF1B57956A00AE9E1C /* BTRAudioHandler.h */,
 				09A5FDF01B57956A00AE9E1C /* BTRAudioHandler.m */,
+				09DBC7571BBAFB6200346912 /* BTRAddPopupController.h */,
+				09DBC7581BBAFB6200346912 /* BTRAddPopupController.m */,
 				093B9AFE1B50E2D500C2ABD0 /* Images.xcassets */,
 				093B9B001B50E2D500C2ABD0 /* Main.storyboard */,
 				09318EEB1B87C5FD00B1E1FE /* Buster.entitlements */,
@@ -535,6 +540,7 @@
 				09F042B61BA1F82600E9F5D2 /* PortMapper.m in Sources */,
 				095544A71B71756F00090DB7 /* BTRVocoderViewController.m in Sources */,
 				09E363EC1B66F46500F74DBB /* BTRSlowDataCoder.m in Sources */,
+				09DBC7591BBAFB6200346912 /* BTRAddPopupController.m in Sources */,
 				0924272E1B62F46600D568DE /* BTRAudioViewController.m in Sources */,
 				09DFDA9F1B8D6A9700D00030 /* BTRIRCDDBGateways.m in Sources */,
 				09E589CA1B7EAC1800A962B5 /* BTRDPlusAuthenticator.m in Sources */,

--- a/Buster/BTRAddPopupController.h
+++ b/Buster/BTRAddPopupController.h
@@ -1,0 +1,17 @@
+//
+//  BTRAddPopupController.h
+//  Buster
+//
+//  Created by Jeremy McDermond on 9/29/15.
+//  Copyright © 2015 NH6Z. All rights reserved.
+//
+
+@interface BTRAddPopupController : NSViewController <NSControlTextEditingDelegate>
+
+@property (nonatomic) NSArrayController *reflectorArrayController;
+@property (weak) IBOutlet NSTextFieldCell *destinationField;
+@property (weak) IBOutlet NSPopUpButton *moduleField;
+
+- (IBAction)doAdd:(id)sender;
+
+@end

--- a/Buster/BTRAddPopupController.m
+++ b/Buster/BTRAddPopupController.m
@@ -1,0 +1,74 @@
+//
+//  BTRAddPopupController.m
+//  Buster
+//
+//  Created by Jeremy McDermond on 9/29/15.
+//  Copyright © 2015 NH6Z. All rights reserved.
+//
+
+#import "BTRAddPopupController.h"
+
+#import "BTRDataEngine.h"
+
+@interface BTRAddPopupController ()
+
+@property (nonatomic, getter=inAutoComplete) BOOL complete;
+@property (nonatomic) NSRange lastCompleteRange;
+
+@end
+
+@implementation BTRAddPopupController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do view setup here.
+}
+
+- (IBAction)doAdd:(id)sender {
+    NSString *linkTarget = [self.destinationField.stringValue stringByPaddingToLength:8 withString:@" " startingAtIndex:0];
+    linkTarget = [linkTarget stringByReplacingCharactersInRange:NSMakeRange(7, 1) withString:self.moduleField.titleOfSelectedItem];
+    
+    NSLog(@"String is %@", linkTarget);
+    [self.reflectorArrayController addObject:@{ @"reflector": linkTarget } ];
+    
+    self.destinationField.stringValue = @"";
+    [self.moduleField selectItemWithTitle:@"A"];
+}
+
+-(NSArray<NSString *> *) control:(NSControl *)control textView:(nonnull NSTextView *)textView completions:(nonnull NSArray<NSString *> *)words forPartialWordRange:(NSRange)charRange indexOfSelectedItem:(nonnull NSInteger *)index {
+    NSLog(@"In completion handler");
+    
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF like[cd] %@", [[textView.string copy] stringByAppendingString:@"*"]];
+    
+    NSArray<NSString *> *destinations = [BTRDataEngine sharedInstance].linkDriverDestinations;
+    NSArray<NSString *> *completionStrings = [destinations filteredArrayUsingPredicate:predicate];
+    
+    *index = -1;
+    return completionStrings;
+}
+
+-(void)controlTextDidChange:(NSNotification *)obj {
+    NSLog(@"Text changed: %@", ((NSTextView *)obj.userInfo[@"NSFieldEditor"]).string);
+
+    if(self.inAutoComplete)
+        return;
+    
+    self.complete = YES;
+    [[[obj userInfo] objectForKey:@"NSFieldEditor"] complete:nil];
+    self.complete = NO;
+}
+
+/* -(BOOL)control:(NSControl *)control textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector {
+    if(commandSelector == @selector(deleteBackward:)) {
+        if(textView.string.length < 1)
+            return NO;
+        
+        self.complete = YES;
+        textView.string = [textView.string substringToIndex:textView.string.length - 1];
+        self.complete = NO;
+        return NO;
+    }
+    
+    return NO;
+} */
+@end

--- a/Buster/BTRDExtraLink.m
+++ b/Buster/BTRDExtraLink.m
@@ -55,6 +55,10 @@ static NSDictionary *_reflectorList;
     [BTRDataEngine registerLinkDriver:self];
 }
 
+-(NSArray<NSString *> *)destinations {
+    return [[BTRDExtraLink reflectorList].allKeys copy];
+}
+
 -(BOOL)canHandleLinkTo:(NSString*)linkTarget {
     if(linkTarget.length != 8)
         return NO;

--- a/Buster/BTRDPlusLink.m
+++ b/Buster/BTRDPlusLink.m
@@ -127,6 +127,13 @@ static const struct dplus_packet linkModuleTemplate = {
     return NO;
 }
 
+-(NSArray<NSString *> *)destinations {
+    NSMutableArray *destinations = [[NSMutableArray alloc] initWithArray:self.authenticator.reflectorList.allKeys];
+    [destinations addObjectsFromArray:self.ircDDBGateways.gateways.allKeys];
+    
+    return destinations;
+}
+
 -(CFAbsoluteTime)pollInterval {
     return 1.0;
 }

--- a/Buster/BTRDataEngine.h
+++ b/Buster/BTRDataEngine.h
@@ -31,6 +31,7 @@
 @property (nonatomic, readonly) BTRAudioHandler *audio;
 @property (nonatomic, readonly) BTRSlowDataCoder *slowData;
 @property (nonatomic) NSObject <BTRDataEngineDelegate> *delegate;
+@property (nonatomic, readonly) NSArray<NSString *> *linkDriverDestinations;
 
 +(BTRDataEngine *)sharedInstance;
 

--- a/Buster/BTRDataEngine.m
+++ b/Buster/BTRDataEngine.m
@@ -124,6 +124,15 @@ static NSMutableArray <Class> *linkDriverClasses = nil;
     return [NSArray arrayWithArray:vocoderDrivers];
 }
 
+-(NSArray<NSString *> *)linkDriverDestinations {
+    NSMutableArray *destinations = [[NSMutableArray alloc] init];
+    
+    for(id <BTRLinkDriverProtocol> driver in self.linkDrivers) {
+        [destinations addObjectsFromArray:driver.destinations];
+    }
+    return destinations;
+}
+
 -(BOOL)isDestinationValid:(NSString *)destination {
     NSUInteger linkIndex = [self.linkDrivers indexOfObjectPassingTest:^BOOL(id <BTRLinkDriverProtocol> obj, NSUInteger idx, BOOL *stop) {
         BOOL test = [obj canHandleLinkTo:destination];

--- a/Buster/BTRLinkDriver.m
+++ b/Buster/BTRLinkDriver.m
@@ -358,6 +358,9 @@
 -(BOOL)canHandleLinkTo:(NSString *)reflector {
     [self doesNotRecognizeSelector:_cmd];
 }
+-(NSArray<NSString *> *)destinations {
+    [self doesNotRecognizeSelector:_cmd];
+}
 #pragma clang diagnostic pop
 
 -(void)setLinkState:(enum linkState)linkState {

--- a/Buster/BTRLinkDriverProtocol.h
+++ b/Buster/BTRLinkDriverProtocol.h
@@ -37,6 +37,7 @@ enum linkState {
 @property (nonatomic, copy)NSString *myCall2;
 @property (nonatomic, weak) NSObject <BTRLinkDriverDelegate> *delegate;
 @property (nonatomic) dispatch_queue_t linkQueue;
+@property (nonatomic, readonly) NSArray<NSString *> *destinations;
 
 -(void)linkTo:(NSString *)linkTarget;
 -(void)unlink;

--- a/Buster/BTRMainWindowViewController.h
+++ b/Buster/BTRMainWindowViewController.h
@@ -34,6 +34,7 @@
 @property MASShortcut *txKeyCode;
 
 
+- (IBAction)doReflectorDoubleClick:(id)sender;
 - (IBAction)doHeardDoubleClick:(id)sender;
 - (IBAction)doLink:(id)sender;
 - (IBAction)addReflector:(id)sender;

--- a/Buster/Base.lproj/Main.storyboard
+++ b/Buster/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="8187.4" systemVersion="14E46" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8191"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="8187.4"/>
         <capability name="box content view" minToolsVersion="7.0"/>
     </dependencies>
     <scenes>
@@ -395,7 +395,7 @@
                                                             <subviews>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="mfa-SF-tPo">
                                                                     <rect key="frame" x="-2" y="0.0" width="76" height="17"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" id="3w7-wp-A8A">
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" id="3w7-wp-A8A">
                                                                         <customFormatter key="formatter" id="PvT-2M-SY3" customClass="BTRDestinationCallFormatter"/>
                                                                         <font key="font" metaFont="fixedUser" size="11"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -420,6 +420,7 @@
                                                 </tableColumn>
                                             </tableColumns>
                                             <connections>
+                                                <action trigger="doubleAction" selector="doReflectorDoubleClick:" target="XfG-lQ-9wD" id="WTc-Jm-gYY"/>
                                                 <binding destination="3qO-F1-Tqi" name="content" keyPath="arrangedObjects" id="5md-w1-YER"/>
                                                 <binding destination="3qO-F1-Tqi" name="selectionIndexes" keyPath="selectionIndexes" previousBinding="5md-w1-YER" id="tWp-Cc-FEN"/>
                                                 <binding destination="3qO-F1-Tqi" name="sortDescriptors" keyPath="sortDescriptors" previousBinding="tWp-Cc-FEN" id="iQm-fE-79q"/>
@@ -934,7 +935,7 @@
                                 </buttonCell>
                                 <connections>
                                     <action selector="addReflector:" target="XfG-lQ-9wD" id="j3y-VF-RfY"/>
-                                    <segue destination="ds4-mU-xKE" kind="popover" popoverAnchorView="Y9w-7c-W1y" popoverBehavior="t" preferredEdge="maxY" id="ZdS-nQ-JcP"/>
+                                    <segue destination="ds4-mU-xKE" kind="popover" identifier="addPopupSegue" popoverAnchorView="Y9w-7c-W1y" popoverBehavior="semitransient" preferredEdge="maxY" id="ZdS-nQ-JcP"/>
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="HHn-S8-cIi" userLabel="Remove Reflector Button">
@@ -1030,10 +1031,10 @@
             </objects>
             <point key="canvasLocation" x="92" y="1053.5"/>
         </scene>
-        <!--View Controller-->
+        <!--Add Popup Controller-->
         <scene sceneID="uh5-Nc-wjp">
             <objects>
-                <viewController id="ds4-mU-xKE" sceneMemberID="viewController">
+                <viewController id="ds4-mU-xKE" customClass="BTRAddPopupController" sceneMemberID="viewController">
                     <view key="view" id="z62-dc-7Gs">
                         <rect key="frame" x="0.0" y="0.0" width="215" height="57"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -1061,24 +1062,41 @@
                             <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fkE-3O-bq1">
                                 <rect key="frame" x="6" y="17" width="96" height="22"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="IkQ-5X-oGN">
-                                    <font key="font" metaFont="system"/>
+                                    <customFormatter key="formatter" id="YUU-m2-Hyh" customClass="BTRCallFormatter">
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="maxLength">
+                                                <integer key="value" value="7"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </customFormatter>
+                                    <font key="font" metaFont="fixedUser" size="11"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
+                                <connections>
+                                    <outlet property="delegate" destination="ds4-mU-xKE" id="zqh-Al-jsa"/>
+                                </connections>
                             </textField>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hPT-oR-XBu">
                                 <rect key="frame" x="167" y="18" width="38" height="19"/>
                                 <buttonCell key="cell" type="roundRect" title="Add" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="hPH-po-C2A">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="titleBar" size="12"/>
+                                    <font key="font" metaFont="cellTitle"/>
                                 </buttonCell>
+                                <connections>
+                                    <action selector="doAdd:" target="ds4-mU-xKE" id="3Q9-E6-wfT"/>
+                                </connections>
                             </button>
                         </subviews>
                     </view>
+                    <connections>
+                        <outlet property="destinationField" destination="IkQ-5X-oGN" id="IFX-cG-yTD"/>
+                        <outlet property="moduleField" destination="R6d-08-H3Q" id="uCn-L5-4aG"/>
+                    </connections>
                 </viewController>
                 <customObject id="M1R-T0-iSp" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="343.5" y="1380.5"/>
+            <point key="canvasLocation" x="318.5" y="1334.5"/>
         </scene>
         <!--Audio-->
         <scene sceneID="elY-lg-nZP">


### PR DESCRIPTION
The previous interface to add a reflector to the favorites was
cumbersome and the double click didn’t really do what was expected.
Nobody really was editing those things, so it didn’t make sense to even
keep them editable.  Double click now links/unlinks reflectors and
there is a popover for adding new reflectors.
